### PR TITLE
Ignore Release/InRelease entries in Release/InRelease

### DIFF
--- a/apt/meta.go
+++ b/apt/meta.go
@@ -159,6 +159,12 @@ func getFilesFromRelease(p string, r io.Reader) ([]*FileInfo, Paragraph, error) 
 		}
 	}
 
+	// WORKAROUND: some (e.g. dell) repositories have invalid Release
+	// that contains wrong checksum for Release itself.  Ignore them.
+	delete(m, "Release")
+	delete(m, "Release.gpg")
+	delete(m, "InRelease")
+
 	l := make([]*FileInfo, 0, len(m))
 	for _, fi := range m {
 		l = append(l, fi)

--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -144,7 +144,7 @@ func NewCacher(config *Config) (*Cacher, error) {
 		}
 	}
 
-	// add meta files w/o checksums (Release, Release.pgp, and InRelease).
+	// add meta files w/o checksums (Release, Release.gpg, and InRelease).
 	for _, fi := range metas {
 		p := fi.Path()
 		if _, ok := c.info[p]; !ok {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -140,12 +140,6 @@ func (m *Mirror) Update(ctx context.Context) error {
 		return errors.New(m.id + ": found no Release/InRelease")
 	}
 
-	// WORKAROUND: some (dell) repositories have invalid Release
-	// that contains wrong checksum for itself.  Ignore them.
-	for _, p := range m.mc.ReleaseFiles() {
-		delete(filMap, p)
-	}
-
 	// WORKAROUND: some (zabbix) repositories returns wrong contents
 	// for non-existent files such as Sources (looks like the body of
 	// Sources.gz is returned).


### PR DESCRIPTION
This was already done for go-apt-mirror but in fact
go-apt-cacher also needs the workaround.

This commit moves the workaround logic from mirror to
a common place in apt/meta.go.

Fixes #13.