### PR TITLE
[WIP] Mirror changes needed to reuse code for `apt-resource` usage.

### DIFF
--- a/cmd/go-apt-mirror/USAGE.md
+++ b/cmd/go-apt-mirror/USAGE.md
@@ -35,7 +35,7 @@ Options
 | ------ | ------- | ----------- |
 | `-f`   | `/etc/apt/mirror.toml` | Configurations |
 
-As `go-apt-cacher` uses [github.com/cybozu-go/cmd](https://github.com/cybozu-go/cmd), flags provided by `cmd` is also available.
+As `go-apt-mirror` uses [github.com/cybozu-go/cmd](https://github.com/cybozu-go/cmd), flags provided by `cmd` is also available.
 
 
 [TOML]: https://github.com/toml-lang/toml

--- a/cmd/go-apt-mirror/main.go
+++ b/cmd/go-apt-mirror/main.go
@@ -38,7 +38,7 @@ func main() {
 		log.ErrorExit(err)
 	}
 
-	err = mirror.Run(config, flag.Args())
+	err = mirror.Run(config, flag.Args(), mirror.Complete)
 	if err != nil {
 		log.ErrorExit(err)
 	}


### PR DESCRIPTION
This is a work in progress pull request to discuss the changes I need to implement an `apt` resource type for Concourse.

After some understanding of the code base and a number of trial attempts, I guess I'm on the right track. I'm converting the code base to a more pipeline oriented approach using channels and goroutines.

The introduction of the strategy allows me to use a `Complete` update for `go-apt-mirror` and a custom implementation for my own work. In this custom implementation, I will only download the release files and indexes, ending with a channel containing the FileInfo structs of all packages in the release. Continuing on that, I can filter the results to the package I want to monitor for new releases.
