### PR TITLE
[cacher] avoid panic for a valid URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - [mirror] could not find Release/InRelease if suites=["/"] (#25, #26).
 - [cacher] create cache directories automatically (#29).  
   Contributed by @jacksgt.
+- [cacher] prevent panic for URL whose path is a mapping prefix (#30).
 
 ## [1.3.2] - 2017-09-01
 ### Changed

--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -333,12 +333,8 @@ func (c *Cacher) download(ctx context.Context, p string, u *url.URL, valid *apt.
 
 	storage := c.items
 	var fil []*apt.FileInfo
-	t := strings.SplitN(path.Clean(p), "/", 2)
-	if len(t) != 2 {
-		panic("path must has a prefix: " + p)
-	}
 
-	if apt.IsMeta(p) {
+	if t := strings.SplitN(path.Clean(p), "/", 2); len(t) == 2 && apt.IsMeta(t[1]) {
 		storage = c.meta
 		fil, _, err = apt.ExtractFileInfo(t[1], bytes.NewReader(body))
 		if err != nil {


### PR DESCRIPTION
As reported in #30, go-apt-cacher panics when it accepts a request
whose path is just a prefix of defined URL mappings.  Instead,
it should proxy the request as is to an upstream.

This commit eliminates the panic.