### PR TITLE
Support to expand environment variable in toml

### DIFF
--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -65,12 +65,12 @@ func NewCacher(config *Config) (*Cacher, error) {
 	checkInterval := time.Duration(config.CheckInterval) * time.Second
 	cachePeriod := time.Duration(config.CachePeriod) * time.Second
 
-	metaDir := filepath.Clean(config.MetaDirectory)
+	metaDir := filepath.Clean(os.ExpandEnv(config.MetaDirectory))
 	if !filepath.IsAbs(metaDir) {
 		return nil, errors.New("meta_dir must be an absolute path")
 	}
 
-	cacheDir := filepath.Clean(config.CacheDirectory)
+	cacheDir := filepath.Clean(os.ExpandEnv(config.CacheDirectory))
 	if !filepath.IsAbs(cacheDir) {
 		return nil, errors.New("cache_dir must be an absolute path")
 	}


### PR DESCRIPTION
Before:
  meta_dir = "/home/user/.../go-apt-cacher/meta"
  cache_dir = "/home/user/.../go-apt-cacher/cache"

After:
  meta_dir = "${HOME}/.../go-apt-cacher/meta"
  cache_dir = "${HOME}/.../go-apt-cacher/cache"

In TOML spec, environment variable is not defined yet and it won't be
added[1], but it is useful that environment variable is support in
go-apt-cacher layer.

[1] https://github.com/toml-lang/toml/issues/255