### PR TITLE
bump CI image and run golangci-lint locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,34 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+executors:
+  go13:
     docker:
-    - image: quay.io/cybozu/golang:1.11-bionic
-    working_directory: /work
+      - image: quay.io/cybozu/golang:1.13-bionic
+jobs:
+  lint:
+    executor: go13
     steps:
-    - checkout
-    - run: test -z "$(gofmt -s -l . | grep -v '^vendor' | tee /dev/stderr)"
-    - run: golint -set_exit_status .
-    - run: go build ./...
-    - run: go test -race -v ./...
-    - run: go vet ./...
+      - checkout
+      - run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          golangci-lint run --new-from-rev=HEAD~
+      - run: test -z "$(gofmt -s -l . | grep -v '^vendor' | tee /dev/stderr)"
+      - run: golint -set_exit_status .
+  test:
+    executor: go13
+    steps:
+      - checkout
+      - run: go test -race -v ./...
+      - run: go vet ./...
+  build:
+    executor: go13
+    steps:
+      - checkout
+      - run: go build ./...
 
 workflows:
   version: 2
   main:
     jobs:
+      - lint
+      - test
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,26 @@
 version: 2.1
 executors:
-  go13:
+  golang:
     docker:
-      - image: quay.io/cybozu/golang:1.13-bionic
+      - image: quay.io/cybozu/golang:1.15-focal
 jobs:
   lint:
-    executor: go13
+    executor: golang
     steps:
       - checkout
       - run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
           golangci-lint run --new-from-rev=HEAD~
       - run: test -z "$(gofmt -s -l . | grep -v '^vendor' | tee /dev/stderr)"
       - run: golint -set_exit_status .
   test:
-    executor: go13
+    executor: golang
     steps:
       - checkout
       - run: go test -race -v ./...
       - run: go vet ./...
   build:
-    executor: go13
+    executor: golang
     steps:
       - checkout
       - run: go build ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,11 @@ jobs:
       - run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
           golangci-lint run --new-from-rev=HEAD~
-      - run: test -z "$(gofmt -s -l . | grep -v '^vendor' | tee /dev/stderr)"
-      - run: golint -set_exit_status .
   test:
     executor: golang
     steps:
       - checkout
       - run: go test -race -v ./...
-      - run: go vet ./...
   build:
     executor: golang
     steps:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Both `go-apt-cacher` and `go-apt-mirror` can be deployed via the [jacksgt/aptuti
 Build
 -----
 
-Use Go 1.7 or better.
+Use Go 1.13 or above.
 
 Run the command below exactly as shown, including the ellipsis.
 They are significant - see `go help packages`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Both `go-apt-cacher` and `go-apt-mirror` can be deployed via the [jacksgt/aptuti
 Build
 -----
 
-Use Go 1.13 or above.
+Use an officially supported version of Go.
 
 Run the command below exactly as shown, including the ellipsis.
 They are significant - see `go help packages`.

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cybozu-go/aptutil
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/cybozu-go/log v1.5.0
-	github.com/cybozu-go/well v1.8.1
+	github.com/cybozu-go/well v1.10.0
 	github.com/pkg/errors v0.8.0
 )
 
-go 1.13
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/cybozu-go/well v1.8.1
 	github.com/pkg/errors v0.8.0
 )
+
+go 1.13


### PR DESCRIPTION
Use the golang:1.13-bionic image instead of the deprecated 1.11 image.
Use golangci-lint locally since the golangci.com service is no longer in operation.