### PR TITLE
refactor(mirror): initialize http.Transport for forward compatibility

### DIFF
--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -91,8 +91,7 @@ func NewMirror(t time.Time, id string, c *Config) (*Mirror, error) {
 	transport := clonedTransport(http.DefaultTransport)
 	if transport == nil {
 		transport = &http.Transport{
-			Proxy:               http.ProxyFromEnvironment,
-			MaxIdleConnsPerHost: c.MaxConns,
+			Proxy: http.ProxyFromEnvironment,
 		}
 	}
 	transport.MaxIdleConnsPerHost = c.MaxConns


### PR DESCRIPTION
Initialize `http.Transport` by cloning `http.DefaultTransport` for forward compatibility.