### PR TITLE
feat(cacher, mirror): set http header by imitation apt-get command

### DIFF
--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -296,13 +296,20 @@ func (c *Cacher) download(ctx context.Context, p string, u *url.URL, valid *apt.
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
 
+	// imitation apt-get command
+	// NOTE: apt-get sets If-Modified-Since and makes a request to the server,
+	// but the current aptutil cannot handle this because it cold-starts every time.
+	header := http.Header{}
+	header.Add("Cache-Control", "max-age=0")
+	header.Add("User-Agent", "Debian APT-HTTP/1.3 (aptutil)")
+
 	req := &http.Request{
 		Method:     "GET",
 		URL:        u,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Header:     make(http.Header),
+		Header:     header,
 	}
 	resp, err := c.client.Do(req.WithContext(ctx))
 	if err != nil {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -326,13 +326,20 @@ RETRY:
 		time.Sleep(time.Duration(1<<(retries-1)) * time.Second)
 	}
 
+	// imitation apt-get command
+	// NOTE: apt-get sets If-Modified-Since and makes a request to the server,
+	// but the current aptutil cannot handle this because it cold-starts every time.
+	header := http.Header{}
+	header.Add("Cache-Control", "max-age=0")
+	header.Add("User-Agent", "Debian APT-HTTP/1.3 (aptutil)")
+
 	req := &http.Request{
 		Method:     "GET",
 		URL:        m.mc.Resolve(targets[0]),
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Header:     make(http.Header),
+		Header:     header,
 	}
 	resp, err := m.client.Do(req.WithContext(ctx))
 	if err != nil {


### PR DESCRIPTION
The server I run checks HTTP headers and changes processing.

I'm not sure if there is a similar use case for other servers, but imitating apt-get while explicitly identifying it as aptutil satisfies my needs ;-)